### PR TITLE
refactor the DNS stuff

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -29,7 +29,7 @@ module "api-gateway" {
 
 locals {
   gateway_info = {
-    address = "https://api-gateway.${var.services_domain}/v1/verify"
+    address = "https://api-gateway.${local.services_domain}/v1/verify"
 
     // Traefik will automagically blacklist these from the request and set
     // them based on the repsonse from the gateway.

--- a/docker.tf
+++ b/docker.tf
@@ -1,6 +1,3 @@
-variable "docker_host" {
-  type = string
-}
 variable "docker_ca_material" {
   type = string
 }

--- a/docker.tf
+++ b/docker.tf
@@ -12,7 +12,7 @@ variable "docker_key_material" {
 }
 
 provider "docker" {
-  host = "tcp://${var.docker_host}:2376/"
+  host = "tcp://${local.docker_host}:2376/"
 
   ca_material   = base64decode(var.docker_ca_material)
   cert_material = base64decode(var.docker_cert_material)

--- a/postgres.tf
+++ b/postgres.tf
@@ -1,8 +1,4 @@
 //// VARIABLES ////
-variable "postgres_host" {
-  type = string
-}
-
 variable "postgres_root_password" {
   type = string
 }
@@ -78,7 +74,7 @@ resource "docker_service" "postgres" {
 
 //// CONNECTION ////
 provider "postgresql" {
-  host            = var.postgres_host
+  host            = local.postgres_host
   username        = "postgres"
   password        = var.postgres_root_password
   sslmode         = "disable"

--- a/scrapedumper.tf
+++ b/scrapedumper.tf
@@ -25,7 +25,7 @@ resource "postgresql_database" "scrapedumper" {
 }
 
 locals {
-  pg_connection_string = "host=${var.postgres_host} user=${postgresql_role.smartadata.name} dbname=${postgresql_database.scrapedumper.name} sslmode=disable"
+  pg_connection_string = "host=${local.postgres_host} user=${postgresql_role.smartadata.name} dbname=${postgresql_database.scrapedumper.name} sslmode=disable"
 }
 
 module "scrapedumper_config" {
@@ -37,7 +37,7 @@ module "scrapedumper_config" {
     pg_connection_string = local.pg_connection_string
   }
 
-  host         = var.docker_host
+  host         = local.docker_host
   user         = var.terraform_host_user
   key_material = var.terraform_host_user_key_material
 }

--- a/traefik.tf
+++ b/traefik.tf
@@ -128,7 +128,7 @@ resource "docker_service" "traefik" {
   }
   labels {
     label = "traefik.http.middlewares.dashboard-auth.basicauth.users"
-    value = "ataperteam:${var.apr1_traefik_dashboard_password}"
+    value = "smartateam:${var.apr1_traefik_dashboard_password}"
   }
 
   endpoint_spec {

--- a/traefik.tf
+++ b/traefik.tf
@@ -2,11 +2,6 @@ variable "lets_encrypt_email" {
   type = string
 }
 
-variable "services_domain" {
-  type    = string
-  default = "services.ataper.net"
-}
-
 variable "apr1_traefik_dashboard_password" {
   type = string
 }
@@ -20,7 +15,7 @@ module "traefik_dynamic_config" {
   source = "./modules/host-file"
 
   template_name   = "traefik.dynamic.toml"
-  host            = var.docker_host
+  host            = local.docker_host
   user            = var.terraform_host_user
   key_material    = var.terraform_host_user_key_material
   destination_dir = var.terraform_host_user_artifacts_root
@@ -30,14 +25,14 @@ module "traefik_config" {
   source = "./modules/host-file"
 
   template_name   = "traefik.toml"
-  host            = var.docker_host
+  host            = local.docker_host
   user            = var.terraform_host_user
   key_material    = var.terraform_host_user_key_material
   destination_dir = var.terraform_host_user_artifacts_root
 
   vars = {
     lets_encrypt_email = var.lets_encrypt_email
-    services_domain    = var.services_domain
+    services_domain    = local.services_domain
     network            = docker_network.traefik.name
     dynamic_toml_path  = "/traefik.dynamic.toml"
   }
@@ -50,7 +45,7 @@ locals {
 resource "null_resource" "acme_dot_json" {
   connection {
     type        = "ssh"
-    host        = var.docker_host
+    host        = local.docker_host
     user        = var.terraform_host_user
     private_key = base64decode(var.terraform_host_user_key_material)
   }

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "smarta_domain" {
 
 locals {
   services_domain = "services.${var.smarta_domain}"
-  production_host = "host1.${var.smarta_domain}"
+  production_host = "smarta-data.${var.smarta_domain}"
   postgres_host   = local.production_host
   docker_host     = local.production_host
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,5 +8,5 @@ locals {
   services_domain = "services.${var.smarta_domain}"
   production_host = "host1.${var.smarta_domain}"
   postgres_host   = local.production_host
-  docker_host     = lcoal.production_host
+  docker_host     = local.production_host
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,12 @@
+variable "smarta_domain" {
+  type        = string
+  description = "the core domain for all things smarta"
+  default     = "ataper.net"
+}
+
+locals {
+  services_domain = "services.${var.smarta_domain}"
+  production_host = "host1.${var.smarta_domain}"
+  postgres_host   = local.production_host
+  docker_host     = lcoal.production_host
+}


### PR DESCRIPTION
This PR doesn't produce any changes in its build plan, it just refactors a bunch of DNS-related variables so that they all come from a single source variable `smarta_domain`. This way, the PR to do DNS switchover will be stupid simple.