### PR TITLE
deploy API gateway from a master build

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -14,7 +14,7 @@ module "api-gateway" {
 
   name      = "api-gateway"
   subdomain = "api-gateway"
-  image     = "smartatransit/api-gateway:build-22"
+  image     = "smartatransit/api-gateway:build-23"
   port      = 8080
 
   env = {


### PR DESCRIPTION
The API gateway was using the `build-22` Docker image tag, which was from the tip of the refactoring branch. I finally merged that to master andI'm bumping it to point to the master build. There shouldn't be any change in functionality.