### PR TITLE
bump logs.io collector and add alternate domains to Traefik TLS

### DIFF
--- a/api.tf
+++ b/api.tf
@@ -26,7 +26,7 @@ module "api-gateway" {
 
   traefik_network_name = docker_network.traefik.id
 
-  smarta_domain     = var.smartatransit
+  smarta_domain     = var.smarta_domain
   alternate_domains = var.alternate_domains
 }
 

--- a/api.tf
+++ b/api.tf
@@ -25,6 +25,9 @@ module "api-gateway" {
   }
 
   traefik_network_name = docker_network.traefik.id
+
+  smarta_domain     = var.smartatransit
+  alternate_domains = var.alternate_domains
 }
 
 locals {

--- a/log_collector.tf
+++ b/log_collector.tf
@@ -10,7 +10,7 @@ resource "docker_service" "log-collector" {
 
   task_spec {
     container_spec {
-      image = "logzio/docker-collector-logs:latest"
+      image = "logzio/docker-collector-logs:0.0.6"
 
       env = {
         LOGZIO_TOKEN = var.logzio_token

--- a/map-demo.tf
+++ b/map-demo.tf
@@ -15,4 +15,7 @@ module "map-demo" {
   }
 
   traefik_network_name = docker_network.traefik.id
+
+  smarta_domain     = var.smartatransit
+  alternate_domains = var.alternate_domains
 }

--- a/map-demo.tf
+++ b/map-demo.tf
@@ -16,6 +16,6 @@ module "map-demo" {
 
   traefik_network_name = docker_network.traefik.id
 
-  smarta_domain     = var.smartatransit
+  smarta_domain     = var.smarta_domain
   alternate_domains = var.alternate_domains
 }

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -47,10 +47,10 @@ locals {
       "traefik.http.routers.${var.name}.entrypoints"               = "web-secure"
       "traefik.http.routers.${var.name}.tls.certResolver"          = "main"
       "traefik.http.services.${var.name}.loadbalancer.server.port" = var.port
-      "traefik.http.routers.<router_name>.tls.domains[0].main"     = "${local.subdomain}.${var.smarta_domain}"
+      "traefik.http.routers.${var.name}.tls.domains[0].main"       = "${local.subdomain}.${var.smarta_domain}"
       }, {
       for san in var.alternate_domains :
-      "traefik.http.routers.<router_name>.tls.domains[0].sans" => "${local.subdomain}.${san}"
+      "traefik.http.routers.${var.name}.tls.domains[0].sans" => "${local.subdomain}.${san}"
     }
   )
 

--- a/modules/service/main.tf
+++ b/modules/service/main.tf
@@ -47,7 +47,7 @@ locals {
       "traefik.http.routers.${var.name}.entrypoints"               = "web-secure"
       "traefik.http.routers.${var.name}.tls.certResolver"          = "main"
       "traefik.http.services.${var.name}.loadbalancer.server.port" = var.port
-      "traefik.http.routers.<router_name>.tls.domains[0].main"     = "${local.subdomain}.${smarta_domain}"
+      "traefik.http.routers.<router_name>.tls.domains[0].main"     = "${local.subdomain}.${var.smarta_domain}"
       }, {
       for san in var.alternate_domains :
       "traefik.http.routers.<router_name>.tls.domains[0].sans" => "${local.subdomain}.${san}"

--- a/smartaslack.tf
+++ b/smartaslack.tf
@@ -20,4 +20,7 @@ module "smartaslack" {
   }
 
   traefik_network_name = docker_network.traefik.id
+
+  smarta_domain     = var.smartatransit
+  alternate_domains = var.alternate_domains
 }

--- a/smartaslack.tf
+++ b/smartaslack.tf
@@ -21,6 +21,6 @@ module "smartaslack" {
 
   traefik_network_name = docker_network.traefik.id
 
-  smarta_domain     = var.smartatransit
+  smarta_domain     = var.smarta_domain
   alternate_domains = var.alternate_domains
 }

--- a/third-rail.tf
+++ b/third-rail.tf
@@ -28,7 +28,7 @@ module "third-rail" {
 
   gateway_info = local.gateway_info
 
-  smarta_domain     = var.smartatransit
+  smarta_domain     = var.smarta_domain
   alternate_domains = var.alternate_domains
 }
 
@@ -47,6 +47,6 @@ module "third-rail-insecure" {
 
   traefik_network_name = docker_network.traefik.id
 
-  smarta_domain     = var.smartatransit
+  smarta_domain     = var.smarta_domain
   alternate_domains = var.alternate_domains
 }

--- a/third-rail.tf
+++ b/third-rail.tf
@@ -27,6 +27,9 @@ module "third-rail" {
   traefik_network_name = docker_network.traefik.id
 
   gateway_info = local.gateway_info
+
+  smarta_domain     = var.smartatransit
+  alternate_domains = var.alternate_domains
 }
 
 module "third-rail-insecure" {
@@ -43,4 +46,7 @@ module "third-rail-insecure" {
   }
 
   traefik_network_name = docker_network.traefik.id
+
+  smarta_domain     = var.smartatransit
+  alternate_domains = var.alternate_domains
 }

--- a/transit-stream.tf
+++ b/transit-stream.tf
@@ -32,6 +32,6 @@ module "transit-stream" {
 
   traefik_network_name = docker_network.traefik.id
 
-  smarta_domain     = var.smartatransit
+  smarta_domain     = var.smarta_domain
   alternate_domains = var.alternate_domains
 }

--- a/transit-stream.tf
+++ b/transit-stream.tf
@@ -31,4 +31,7 @@ module "transit-stream" {
   }
 
   traefik_network_name = docker_network.traefik.id
+
+  smarta_domain     = var.smartatransit
+  alternate_domains = var.alternate_domains
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "smarta_domain" {
   default     = "smartatransit.com"
 }
 
+variable "alternate_domains" {
+  type        = list(string)
+  description = "TLS SANs for the main SMARTA domain"
+  default     = ["smartatransit.net"]
+}
+
 locals {
   services_domain = "services.${var.smarta_domain}"
   production_host = "smarta-data.${var.smarta_domain}"


### PR DESCRIPTION
- Bump the logz-io image to the latest version (and also pin it to that version) because [this notice](https://docs.logz.io/technical-notes/chain-of-trust/?mkt_tok=eyJpIjoiWldReE4yRTFNVFkzTlRjeCIsInQiOiJuUXNMTlpTVjFhXC9tS1BYUlhOYTY2S20yNWdYbkZMR3FvXC84c1wva0RKQ0J5dzZKVVI2a0pkTm55dGxGRHJuWEw4MTF0UklZZHZVd2RTUWYxckw3bkw5cXVoemh4d1N0c1ZqWXk0eGx3cUxwdWhRZE41VXpuMzRBUldsMkJzcW9qRSJ9#update-container) says logz.io is cycling their certificates and we need to update to avoid breaking
- Update our Traefik configuration with some new goodies that _might_ allow us to generate alternate-domain certs for smartatransit.net 🤞