### PR TITLE
traefik routing for *.net hostnames

### DIFF
--- a/templates/traefik.toml
+++ b/templates/traefik.toml
@@ -13,7 +13,7 @@
     swarmMode = true
     exposedByDefault = false
     network = "${network}"
-    defaultRule = "Host(`{{ default .Name (index .Labels \"smarta.subdomain\") }}.${services_domain}`)"
+    defaultRule = "{default_rule}"
   [providers.file]
     watch = true
     filename = "${dynamic_toml_path}"

--- a/traefik.tf
+++ b/traefik.tf
@@ -21,6 +21,13 @@ module "traefik_dynamic_config" {
   destination_dir = var.terraform_host_user_artifacts_root
 }
 
+locals {
+  host_snis = [
+    for domain in local.all_services_domains :
+    "`{{ default .Name (index .Labels \"smarta.subdomain\") }}.${domain}`"
+  ]
+}
+
 module "traefik_config" {
   source = "./modules/host-file"
 
@@ -32,9 +39,10 @@ module "traefik_config" {
 
   vars = {
     lets_encrypt_email = var.lets_encrypt_email
-    services_domain    = local.services_domain
     network            = docker_network.traefik.name
     dynamic_toml_path  = "/traefik.dynamic.toml"
+
+    default_rule = "HostSNI(${join(",", local.host_snis)})"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,7 @@ variable "alternate_base_domains" {
 locals {
   services_domain            = "services.${var.smarta_domain}"
   alternate_services_domains = [for alt in var.alternate_base_domains : "services.${alt}"]
+  all_services_domains       = concat([local.services_domain], local.alternate_services_domains)
 
   production_host = "smarta-data.${var.smarta_domain}"
   postgres_host   = local.production_host


### PR DESCRIPTION
It looks like we're successfully generating certs for not just `mysvc.services.smartatransit.com` but also `mysvc.services.smartatransit.net`! There's one link in the chain missing though: when Traefik receives a `.net` request, it doesn't know that it should route that to the same backend as the .com, so it responds with 404 (albeit this 404 now comes with a valid TLS cert!)

This update doesn't change our individual service configs, it just changes the global Traefik config. That config contains a "default rule template" that gets applied to each docker-based router, and I'm expanding that rule to match against a list of domains instead of just the one 🤞